### PR TITLE
don't pass data to repeated prep()

### DIFF
--- a/R/sparseR_prep.R
+++ b/R/sparseR_prep.R
@@ -165,7 +165,7 @@ sparseR_prep <- function(formula, data, k = 1, poly = 1,
   rec_obj <- rec_obj_early
 
   # Create interactions if necessary
-  prec_obj <- prep(rec_obj, data = data)
+  prec_obj <- prep(rec_obj)
   has_predictors <- any(prec_obj$term_info$role == "predictor")
 
   if(k > 0) {
@@ -216,8 +216,7 @@ sparseR_prep <- function(formula, data, k = 1, poly = 1,
     warning("Recommend at least filtering zv for extraneous interaction effects")
 
   ## Prep recipe
-  final_rec <- rec_obj %>%
-    prep(data)
+  final_rec <- prep(rec_obj)
 
   ## Fix tr_info for earlier prepped version
   final_rec$tr_info <- rec_obj_early$tr_info


### PR DESCRIPTION
Hello @petersonR 👋 

I'm hoping to be doing a release of {recipes} soon. One of the recent improvements is better and more informative errors and warnings. One of which popped up in my revdepcheck.

When using a recipe, re-prepping a recipe will ignore the `training` argument unless `fresh = TRUE` is specified. The new version will now correctly throw that warning. (it was always intended but there was a typo in the triggering code 😅 )

```r
library(recipes)

rec <- recipe(~ ., data = mtcars) |>
  step_center(mpg, disp) |>
  prep()

tmp <- rec |> prep()
tmp <- rec |> prep(training = mtcars)
#> Warning in prep(rec, training = mtcars): 
#> ! The previous data will be used by `prep()`.
#> ℹ The data passed using `training` will be ignored.
```

This PR fixes that and can be merged right way!

I would appreciate if you would be able to do a CRAN release which this bug fix, as I would like to do a CRAN release of recipes before Dec 20th. 